### PR TITLE
FreeBSD port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udt"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrew Chin <achin@eminence32.net>"]
 keywords = ["udp", "socket", "udt", "udt4"]
 readme = "README.md"
@@ -10,6 +10,7 @@ description = """
 Bindings to udt, a high performance data transfer protocol (based on UDP)
 """
 license = "BSD-3-Clause"
+edition = "2018"
 
 [dependencies]
 libudt4-sys = {path = "libudt4-sys", version="0.2"}

--- a/libudt4-sys/Cargo.toml
+++ b/libudt4-sys/Cargo.toml
@@ -2,21 +2,22 @@
 name = "libudt4-sys"
 authors = ["Andrew Chin <achin@eminence32.net>"]
 build = "build.rs"
-version = "0.2.0"
+version = "0.2.1"
 links = "udt4wrap"
 description = "Native bindings to a C wrapper around the UDT library"
 license = "BSD-3-Clause"
 repository = "https://github.com/eminence/udt-rs"
+edition = "2018"
 
 [lib]
 name = "libudt4_sys"
 path = "lib.rs"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "^1.0"
 
 [dependencies]
-libc = "0.2"
+libc = "^0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
+winapi = "^0.2"

--- a/libudt4-sys/build.rs
+++ b/libudt4-sys/build.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+
 
 use std::path::PathBuf;
 use std::fs::{read_dir};
@@ -23,7 +23,7 @@ fn main() {
     }
 
     // g++ -fPIC -Wall -Wextra -DLINUX -finline-functions -O3 -fno-strict-aliasing -fvisibility=hidden -DAMD64 ccc.cpp -c
-    let mut cfg = gcc::Config::new();
+    let mut cfg = cc::Build::new();
     for file in cpp_files {
         cfg.file(file);
     }
@@ -63,7 +63,7 @@ fn main() {
             .flag("/Gm-") // disable minimal rebuild
             .flag("/EHsc")// enable c++ exceptions
             .flag("/MD"); // multi-threaded DLL runtime
-    } else {	
+    } else {
         cfg.flag("-fPIC")
            .opt_level(3)
            .flag("-Wextra")


### PR DESCRIPTION
* Updated manifests and source code to Rust edition 2018
* Updated `make.rs` from unmaintaned `gcc` crate to `cc` crate
* Run through `cargo fmt`
* Tweaked source to compile on FreeBSD
  - `get_sockaddr()` of MacOS is compatible with FreeBSD
  - `do_platform_specific_init()` of MacOS is compatible with FreeBSD

Regular tests:
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Doc-tests:
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

> uname -a
FreeBSD MaxBSD-2 12.0-RELEASE-p6 FreeBSD 12.0-RELEASE-p6 GENERIC  amd64